### PR TITLE
ndcli - fix version string returned by ndcli

### DIFF
--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -14,11 +14,9 @@ from operator import itemgetter
 from . import zoneimport
 from .cliparse import Command, Option, Group, Argument, Token
 
-
-__version__ = '2.4.0'
+__version__ = '3.0.0'
 
 logger = logging.getLogger('ndcli')
-
 
 def _readconfig(config_file):
     config = {}

--- a/ndcli/requirements.txt
+++ b/ndcli/requirements.txt
@@ -1,3 +1,3 @@
-python-dateutil==1.4.1
-dnspython==1.12.0
+python-dateutil>=1.4.1
+dnspython>=1.12.0
 

--- a/ndcli/setup.py
+++ b/ndcli/setup.py
@@ -1,7 +1,25 @@
 from setuptools import setup
+import codecs
+import os
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    # intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            # __version__ = "0.9"
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
 
 setup(name='ndcli',
-      version='2.4.0',
+      version=get_version('dimcli/__init__.py'),
       scripts=['ndcli'],
       install_requires=['dimclient>=0.4.1',
                         'python-dateutil',


### PR DESCRIPTION
As the version string wasn't updated in some time, we should fix it.
According to
https://packaging.python.org/guides/single-sourcing-package-version/
this is the way to go.